### PR TITLE
Fixes issue #16.

### DIFF
--- a/pikatools/pool.py
+++ b/pikatools/pool.py
@@ -148,8 +148,7 @@ class Connection:
     connectivity_errors = (
         pika.exceptions.AMQPConnectionError,
         pika.exceptions.ConnectionClosed,
-        pika.exceptions.ChannelClosed,
-        select.error,  # XXX: https://github.com/pika/pika/issues/412
+        pika.exceptions.ChannelClosed
     )
 
     @classmethod

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -40,7 +40,6 @@ POSSIBILITY OF SUCH DAMAGE.
 from __future__ import unicode_literals
 
 import json
-import select
 import threading
 import time
 import uuid
@@ -185,10 +184,10 @@ class TestQueuedPool(object):
 
     def test_invalidate_connection(slef, queued_pool):
         msg = Message.generate()
-        with pytest.raises(select.error):
+        with pytest.raises(pika.exceptions.AMQPConnectionError):
             with queued_pool.acquire() as cxn:
                 fairy = cxn.fairy
-                raise select.error(9, 'Bad file descriptor')
+                raise pika.exceptions.AMQPConnectionError
         assert fairy.cxn.is_closed
 
     def test_pub(self, queued_pool):


### PR DESCRIPTION
* pool.py: Remove `select.error` from tuple of connectivity errors.
* tests/test_pool.py: Change `test_invalidate_connection()` to
depend on `pika.exceptions.AMQPConnectionError`.