### PR TITLE
Ensure connections closed.

### DIFF
--- a/pikatools/pool.py
+++ b/pikatools/pool.py
@@ -87,6 +87,7 @@ Use it like e.g. this:
 
 from datetime import datetime
 import logging
+import weakref
 
 import queue
 
@@ -242,6 +243,7 @@ class Pool:
         """
 
         def __init__(self, cxn):
+            weakref.finalize(cxn, cxn.close)
             self.cxn = cxn
             self.channel = None
 


### PR DESCRIPTION
Set a `weakref.finalize()` object to call `cxn.close()` when
`Fairy` objects are created. Ensures that the connections are
closed when the program exits and the pool is torn down.

Issue #26.